### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol server that provides read-only access to Ontotext GraphDB. This server enables LLMs to explore RDF graphs and execute SPARQL queries against a GraphDB instance.
 
+<a href="https://glama.ai/mcp/servers/@keonchennl/mcp-graphdb">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@keonchennl/mcp-graphdb/badge" alt="GraphDB Server MCP server" />
+</a>
+
 ## Components
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [GraphDB MCP Server](https://glama.ai/mcp/servers/@keonchennl/mcp-graphdb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@keonchennl/mcp-graphdb">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@keonchennl/mcp-graphdb/badge" alt="GraphDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.